### PR TITLE
Fix NPE in reverse optimizing rent edge

### DIFF
--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -411,6 +411,7 @@ public class StateEditor {
         cloneStateDataAsNeeded();
         child.stateData.currentTraverseMode = vehicleDescription.getTraverseMode();
         child.stateData.currentVehicle = vehicleDescription;
+        child.distanceTraversedInCurrentVehicle = 0;
         int droppingTime = child.getOptions().routingDelays.getDropoffTime(child.getCurrentVehicle());
         incrementTimeInSeconds(droppingTime);
     }

--- a/src/test/java/org/opentripplanner/routing/core/StateEditorTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/StateEditorTest.java
@@ -1,15 +1,44 @@
 package org.opentripplanner.routing.core;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.opentripplanner.routing.core.vehicle_sharing.CarDescription;
+import org.opentripplanner.routing.core.vehicle_sharing.FuelType;
+import org.opentripplanner.routing.core.vehicle_sharing.Gearbox;
+import org.opentripplanner.routing.core.vehicle_sharing.Provider;
+import org.opentripplanner.routing.edgetype.rentedgetype.RentVehicleAnywhereEdge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.StreetVertexIndexServiceImpl;
+import org.opentripplanner.routing.vertextype.IntersectionVertex;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class StateEditorTest {
 
+    private static final CarDescription CAR_1 = new CarDescription("1", 0, 0, FuelType.ELECTRIC, Gearbox.AUTOMATIC, new Provider(2, "PANEK"));
+    private static final double DELTA = 0.1;
+
+    private State state, rentingState;
+    private RoutingRequest request;
+    private RentVehicleAnywhereEdge rentVehicleAnywhereEdge;
+
+    @Before
+    public void setUp() {
+        Graph graph = new Graph();
+        IntersectionVertex v = new IntersectionVertex(graph, "v_name", 0, 0);
+        rentVehicleAnywhereEdge = new RentVehicleAnywhereEdge(v);
+        request = new RoutingRequest();
+        request.setDummyRoutingContext(graph);
+        request.setModes(new TraverseModeSet(TraverseMode.WALK, TraverseMode.CAR));
+        request.setStartingMode(TraverseMode.WALK);
+        state = new State(v, request);
+        StateEditor se = state.edit(rentVehicleAnywhereEdge);
+        se.beginVehicleRenting(CAR_1);
+        rentingState = se.makeState();
+    }
+
     @Test
-    public final void testIncrementTimeInSeconds() {
+    public void testIncrementTimeInSeconds() {
         RoutingRequest routingRequest = new RoutingRequest();
         StateEditor stateEditor = new StateEditor(routingRequest, null);
 
@@ -23,7 +52,7 @@ public class StateEditorTest {
      * Test update of non transit options.
      */
     @Test
-    public final void testSetNonTransitOptionsFromState(){
+    public void testSetNonTransitOptionsFromState() {
         RoutingRequest request = new RoutingRequest();
         request.setMode(TraverseMode.CAR);
         request.parkAndRide = true;
@@ -41,8 +70,72 @@ public class StateEditorTest {
         se.setNonTransitOptionsFromState(state);
         State updatedState = se.makeState();
         assertEquals(TraverseMode.WALK, updatedState.getNonTransitMode());
-        assertEquals(true, updatedState.isCarParked());
-        assertEquals(true, updatedState.isBikeParked());
-        assertEquals(false, updatedState.isBikeRenting());
+        assertTrue(updatedState.isCarParked());
+        assertTrue(updatedState.isBikeParked());
+        assertFalse(updatedState.isBikeRenting());
+    }
+
+    @Test
+    public void shouldAllowRentingVehicles() {
+        // given
+        StateEditor stateEditor = state.edit(rentVehicleAnywhereEdge);
+
+        // when
+        stateEditor.beginVehicleRenting(CAR_1);
+        State next = stateEditor.makeState();
+
+        // then
+        assertEquals(TraverseMode.CAR, next.getNonTransitMode());
+        assertEquals(CAR_1, next.getCurrentVehicle());
+        assertEquals(0, next.distanceTraversedInCurrentVehicle, DELTA);
+        assertEquals(state.time + request.routingDelays.getRentingTime(CAR_1) * 1000, next.time);
+        assertEquals(state.weight + request.routingDelays.getRentingTime(CAR_1) * request.routingReluctances.getRentingReluctance(), next.weight, DELTA);
+    }
+
+    @Test
+    public void shouldAllowDroppingOffVehicles() {
+        // given
+        StateEditor stateEditor = rentingState.edit(rentVehicleAnywhereEdge);
+
+        // when
+        stateEditor.doneVehicleRenting();
+        State next = stateEditor.makeState();
+
+        // then
+        assertEquals(TraverseMode.WALK, next.getNonTransitMode());
+        assertNull(next.getCurrentVehicle());
+        assertEquals(rentingState.time + request.routingDelays.getDropoffTime(CAR_1) * 1000, next.time);
+        assertEquals(rentingState.weight + request.routingDelays.getDropoffTime(CAR_1) * request.routingReluctances.getRentingReluctance(), next.weight, DELTA);
+    }
+
+    @Test
+    public void shouldAllowReverseRentingVehicles() {
+        // given
+        StateEditor stateEditor = rentingState.edit(rentVehicleAnywhereEdge);
+
+        // when
+        stateEditor.reversedBeginVehicleRenting();
+        State next = stateEditor.makeState();
+
+        // then: we drop off a car, but in renting time
+        assertEquals(TraverseMode.WALK, next.getNonTransitMode());
+        assertNull(next.getCurrentVehicle());
+        assertEquals(rentingState.time + request.routingDelays.getRentingTime(CAR_1) * 1000, next.time);
+    }
+
+    @Test
+    public void shouldAllowReverseDroppingOffVehicles() {
+        // given
+        StateEditor stateEditor = state.edit(rentVehicleAnywhereEdge);
+
+        // when
+        stateEditor.reversedDoneVehicleRenting(CAR_1);
+        State next = stateEditor.makeState();
+
+        // then: we rent a car, but in dropoff time
+        assertEquals(TraverseMode.CAR, next.getNonTransitMode());
+        assertEquals(CAR_1, next.getCurrentVehicle());
+        assertEquals(0, next.distanceTraversedInCurrentVehicle, DELTA);
+        assertEquals(state.time + request.routingDelays.getDropoffTime(CAR_1) * 1000, next.time);
     }
 }


### PR DESCRIPTION
Przy `reverse optimize` powinniśmy zerować licznik `distanceTraversedInCurrentVehicle` przed każdym wypożyczeniem pojazdu - w przeciwnym wypadku dystanse pokonane w kolejnych pojazdach się kumulują, a po jakimś czasie przekraczają maksymalny dystans jednego z tych pojazdów.