### PR TITLE
Allow adding simulator classes to OTP shaded jar for snapshot downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,8 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
-                                        <exclude>org/opentripplanner/estimator/**/*</exclude>
+                                        <!-- TODO: Paulina Adamska VMP-239 Uncomment the line below
+                                        <exclude>org/opentripplanner/estimator/**/*</exclude>-->
                                         <exclude>com/github/tomakehurst/**/*</exclude>
                                     </excludes>
                                 </filter>


### PR DESCRIPTION
Minor but crucial fix temporarily allowing to add simulator associated classes to the shaded jar before moving some of them to the main OTP packages to avoid ClassNotFoundException after deployment